### PR TITLE
Create a variable to 64-bit processor

### DIFF
--- a/prebuilt.mk
+++ b/prebuilt.mk
@@ -7,15 +7,19 @@ add-prebuilt-files:
 	$(call copy-apks-lib,$(MIUI_APPS),$(PREBUILT_APP_LIB_DIR),$(TARGET_APP_DIR))
 	$(call copy-apks-lib,$(MIUI_PRIV_APPS),$(PREBUILT_PRIV_APP_LIB_DIR),$(TARGET_PRIV_APP_DIR))
 	$(call copy-prebuilt-files,$(PREBUILT_LIB_DIR),$(TARGET_LIB_DIR),lib)
+	ifeq ($(strip $(local-target-bit)),64)
 	$(call copy-prebuilt-files,$(PREBUILT_LIB64_DIR),$(TARGET_LIB64_DIR),lib64)
+	endif
 	$(call copy-prebuilt-files,$(PREBUILT_JAR_DIR),$(TARGET_FRAMEWORK_DIR),framework)
 	$(call copy-prebuilt-files,$(PREBUILT_ETC_DIR),$(TARGET_ETC_DIR),etc)
 	$(call copy-prebuilt-files,$(PREBUILT_BIN_DIR),$(TARGET_BIN_DIR),bin)
 	$(call copy-prebuilt-files,$(PREBUILT_XBIN_DIR),$(TARGET_XBIN_DIR),xbin)
 	$(call copy-prebuilt-files,$(PREBUILT_MEDIA_DIR),$(TARGET_MEDIA_DIR),media)
 	$(hide) cp -f $(PREBUILT_FONTS_DIR)/Miui*.ttf $(TARGET_FONTS_DIR)/
+	ifeq ($(strip $(local-target-bit)),64)
 	$(hide) -cp -f $(STOCKROM_DIR)/system/bin/app_process64 $(TARGET_BIN_DIR)/app_process64_vendor
 	$(hide) -mv -f $(TARGET_BIN_DIR)/app_process64_miui $(TARGET_BIN_DIR)/app_process64
+	endif
 	$(hide) -cp -f $(STOCKROM_DIR)/system/bin/app_process32 $(TARGET_BIN_DIR)/app_process32_vendor
 	$(hide) -mv -f $(TARGET_BIN_DIR)/app_process32_miui $(TARGET_BIN_DIR)/app_process32
 


### PR DESCRIPTION
Copy 64-bit files only on 64-bit processor, if not, the patchrom will create useless lib64 folder on 32-bit processor.